### PR TITLE
Fixing typos and errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ pkgs
 .Rproj.user
 arrow.Rcheck/
 docker_cache
+/.vs

--- a/csharp/src/Apache.Arrow/Arrays/Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Array.cs
@@ -37,10 +37,7 @@ namespace Apache.Arrow
 
         public ArrowBuffer NullBitmapBuffer => Data.Buffers[0];
 
-        public virtual void Accept(IArrowArrayVisitor visitor)
-        {
-            Accept(this, visitor);
-        }
+        public abstract void Accept(IArrowArrayVisitor visitor);
 
         public bool IsValid(int index) =>
             NullBitmapBuffer == null || NullBitmap.IsSet(index);

--- a/csharp/src/Apache.Arrow/ArrowBuffer.Builder.cs
+++ b/csharp/src/Apache.Arrow/ArrowBuffer.Builder.cs
@@ -54,6 +54,7 @@ namespace Apache.Arrow
                     // TODO: Consider a specifiable growth strategy
 
                     _memory = _pool.Reallocate(_memory, (_memory.Length * 3) / 2);
+                    span = GetSpan();
                 }
 
                 span[_offset++] = value;

--- a/csharp/src/Apache.Arrow/Types/ArrowType.cs
+++ b/csharp/src/Apache.Arrow/Types/ArrowType.cs
@@ -15,7 +15,7 @@
 
 namespace Apache.Arrow.Types
 {
-    public abstract class ArrowType: IArrowType
+    public abstract class ArrowType : IArrowType
     {
         public abstract ArrowTypeId TypeId { get; }
 
@@ -24,5 +24,17 @@ namespace Apache.Arrow.Types
         public virtual bool IsFixedWidth => false;
 
         public abstract void Accept(IArrowTypeVisitor visitor);
+
+        internal static void Accept<T>(T arrowType, IArrowTypeVisitor visitor) where T : IArrowType
+        {
+            if (visitor is IArrowTypeVisitor<T> v)
+            {
+                v.Visit(arrowType);
+            }
+            else
+            {
+                visitor.Visit(arrowType);
+            }
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Types/BinaryType.cs
+++ b/csharp/src/Apache.Arrow/Types/BinaryType.cs
@@ -19,17 +19,13 @@ using System.Text;
 
 namespace Apache.Arrow.Types
 {
-    public class BinaryType: ArrowType
+    public class BinaryType : ArrowType
     {
         public static readonly BinaryType Default = new BinaryType();
 
         public override ArrowTypeId TypeId => ArrowTypeId.Binary;
         public override string Name => "binary";
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<BinaryType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/BooleanType.cs
+++ b/csharp/src/Apache.Arrow/Types/BooleanType.cs
@@ -28,10 +28,6 @@ namespace Apache.Arrow.Types
         public override int BitWidth => 1;
         public override bool IsSigned => false;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<BooleanType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/BooleanType.cs
+++ b/csharp/src/Apache.Arrow/Types/BooleanType.cs
@@ -30,7 +30,7 @@ namespace Apache.Arrow.Types
 
         public override void Accept(IArrowTypeVisitor visitor)
         {
-            if (visitor is IArrowTypeVisitor<Int8Type> v)
+            if (visitor is IArrowTypeVisitor<BooleanType> v)
                 v.Visit(this);
         }
     }

--- a/csharp/src/Apache.Arrow/Types/Date32Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Date32Type.cs
@@ -28,10 +28,6 @@ namespace Apache.Arrow.Types
         public override int BitWidth => 32;
         public override DateUnit Unit => DateUnit.Day;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<Date32Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/Date64Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Date64Type.cs
@@ -28,10 +28,6 @@ namespace Apache.Arrow.Types
         public override int BitWidth => 64;
         public override DateUnit Unit => DateUnit.Milliseconds;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<Date64Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/DoubleType.cs
+++ b/csharp/src/Apache.Arrow/Types/DoubleType.cs
@@ -29,10 +29,6 @@ namespace Apache.Arrow.Types
         public override bool IsSigned => true;
         public override PrecisionKind Precision => PrecisionKind.Double;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<DoubleType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/FixedSizeBinaryType.cs
+++ b/csharp/src/Apache.Arrow/Types/FixedSizeBinaryType.cs
@@ -34,11 +34,7 @@ namespace Apache.Arrow.Types
             ByteWidth = byteWidth;
         }
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<FixedSizeBinaryType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
 
         
     }

--- a/csharp/src/Apache.Arrow/Types/FloatType.cs
+++ b/csharp/src/Apache.Arrow/Types/FloatType.cs
@@ -29,10 +29,6 @@ namespace Apache.Arrow.Types
         public override bool IsSigned => true;
         public override PrecisionKind Precision => PrecisionKind.Single;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<FloatType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/HalfFloatType.cs
+++ b/csharp/src/Apache.Arrow/Types/HalfFloatType.cs
@@ -29,10 +29,6 @@ namespace Apache.Arrow.Types
         public override bool IsSigned => true;
         public override PrecisionKind Precision => PrecisionKind.Half;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<HalfFloatType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/Int16Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Int16Type.cs
@@ -24,10 +24,6 @@ namespace Apache.Arrow.Types
         public override int BitWidth => 16;
         public override bool IsSigned => true;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<Int16Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/Int32Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Int32Type.cs
@@ -24,10 +24,6 @@ namespace Apache.Arrow.Types
         public override int BitWidth => 32;
         public override bool IsSigned => true;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<Int32Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/Int64Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Int64Type.cs
@@ -24,10 +24,6 @@ namespace Apache.Arrow.Types
         public override int BitWidth => 64;
         public override bool IsSigned => true;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<Int64Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/Int8Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Int8Type.cs
@@ -28,10 +28,6 @@ namespace Apache.Arrow.Types
         public override int BitWidth => 8;
         public override bool IsSigned => true;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<Int8Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/IntervalUnit.cs
+++ b/csharp/src/Apache.Arrow/Types/IntervalUnit.cs
@@ -38,10 +38,6 @@ namespace Apache.Arrow.Types
             Unit = unit;
         }
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<IntervalType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/ListType.cs
+++ b/csharp/src/Apache.Arrow/Types/ListType.cs
@@ -33,10 +33,6 @@ namespace Apache.Arrow.Types
             ValueDataType = valueDataType ?? NullType.Default;
         }
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<ListType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/NullType.cs
+++ b/csharp/src/Apache.Arrow/Types/NullType.cs
@@ -26,10 +26,6 @@ namespace Apache.Arrow.Types
         public override ArrowTypeId TypeId => ArrowTypeId.Null;
         public override string Name => "null";
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<NullType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/StringType.cs
+++ b/csharp/src/Apache.Arrow/Types/StringType.cs
@@ -26,10 +26,6 @@ namespace Apache.Arrow.Types
         public override ArrowTypeId TypeId => ArrowTypeId.String;
         public override string Name => "utf8";
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<StringType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/StructType.cs
+++ b/csharp/src/Apache.Arrow/Types/StructType.cs
@@ -55,10 +55,6 @@ namespace Apache.Arrow.Types
                 field => comparer.Equals(field.Name, name));
         }
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<StructType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/Time32Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Time32Type.cs
@@ -30,10 +30,6 @@ namespace Apache.Arrow.Types
         public Time32Type(TimeUnit unit = TimeUnit.Millisecond)
             : base(unit) { }
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<Time32Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/Time32Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Time32Type.cs
@@ -32,7 +32,7 @@ namespace Apache.Arrow.Types
 
         public override void Accept(IArrowTypeVisitor visitor)
         {
-            if (visitor is IArrowTypeVisitor<Int16Type> v)
+            if (visitor is IArrowTypeVisitor<Time32Type> v)
                 v.Visit(this);
         }
     }

--- a/csharp/src/Apache.Arrow/Types/Time64Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Time64Type.cs
@@ -30,10 +30,6 @@ namespace Apache.Arrow.Types
         public Time64Type(TimeUnit unit = TimeUnit.Millisecond)
             : base(unit) { }
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<Time64Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/TimestampType.cs
+++ b/csharp/src/Apache.Arrow/Types/TimestampType.cs
@@ -38,10 +38,6 @@ namespace Apache.Arrow.Types
             Timezone = timezone;
         }
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<TimestampType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/UInt16Type.cs
+++ b/csharp/src/Apache.Arrow/Types/UInt16Type.cs
@@ -24,10 +24,6 @@ namespace Apache.Arrow.Types
         public override int BitWidth => 16;
         public override bool IsSigned => false;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<UInt16Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/UInt32Type.cs
+++ b/csharp/src/Apache.Arrow/Types/UInt32Type.cs
@@ -24,10 +24,6 @@ namespace Apache.Arrow.Types
         public override int BitWidth => 32;
         public override bool IsSigned => false;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<UInt32Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/UInt64Type.cs
+++ b/csharp/src/Apache.Arrow/Types/UInt64Type.cs
@@ -24,10 +24,6 @@ namespace Apache.Arrow.Types
         public override int BitWidth => 64;
         public override bool IsSigned => false;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<UInt64Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/UInt8Type.cs
+++ b/csharp/src/Apache.Arrow/Types/UInt8Type.cs
@@ -26,7 +26,7 @@ namespace Apache.Arrow.Types
 
         public override void Accept(IArrowTypeVisitor visitor)
         {
-            if (visitor is IArrowTypeVisitor<Int8Type> v)
+            if (visitor is IArrowTypeVisitor<UInt8Type> v)
                 v.Visit(this);
         }
     }

--- a/csharp/src/Apache.Arrow/Types/UInt8Type.cs
+++ b/csharp/src/Apache.Arrow/Types/UInt8Type.cs
@@ -24,10 +24,6 @@ namespace Apache.Arrow.Types
         public override int BitWidth => 8;
         public override bool IsSigned => false;
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<UInt8Type> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/UnionType.cs
+++ b/csharp/src/Apache.Arrow/Types/UnionType.cs
@@ -41,10 +41,6 @@ namespace Apache.Arrow.Types
             Mode = mode;
         }
 
-        public override void Accept(IArrowTypeVisitor visitor)
-        {
-            if (visitor is IArrowTypeVisitor<UnionType> v)
-                v.Visit(this);
-        }
+        public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }


### PR DESCRIPTION
The span the new value was written to was pointing to the previous memory allocation.